### PR TITLE
Fix missing comma in SECRET_KEY to fix configuration issue

### DIFF
--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '^##ydkswfu0+=ofw0l#$kv^8n)0$i(qd&d&ol#p9!b$8*5%j1+
+SECRET_KEY = '^##ydkswfu0+=ofw0l#$kv^8n)0$i(qd&d&ol#p9!b$8*5%j1+'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
### Descripción:
Este commit corrige un error en el archivo settings.py donde faltaba una coma en la variable secret key. esta configuracion hace que el ser


Closes #1 